### PR TITLE
Do not persist design panel on story changes

### DIFF
--- a/packages/examples/stories/index.stories.js
+++ b/packages/examples/stories/index.stories.js
@@ -149,3 +149,18 @@ storiesOf('Tests|Placeholder', module)
       }
     }
   )
+
+storiesOf('Tests|Issues/#14', module)
+  .addDecorator(withDesign)
+  .add('Do not persist addon panel (step 1)', () => <Button>Button</Button>, {
+    design: config({
+      type: 'figma',
+      url:
+        'https://www.figma.com/file/Klm6pxIZSaJFiOMX5FpTul9F/storybook-addon-designs-sample'
+    })
+  })
+
+storiesOf('Tests|Issues/#14', module).add(
+  'Do not persist addon panel (step 2)',
+  () => <Button>Button</Button>
+)

--- a/packages/storybook-addon-designs/src/register/components/Wrapper.tsx
+++ b/packages/storybook-addon-designs/src/register/components/Wrapper.tsx
@@ -32,9 +32,7 @@ export const Wrapper: SFC<Props> = ({ active, api, channel }) => {
 
       const cfg = api.getParameters(id, ParameterName)
 
-      if (cfg !== config) {
-        setConfig(cfg)
-      }
+      setConfig(prev => (cfg !== prev ? cfg : prev))
     }
 
     channel.on(Events.UpdateConfig, setConfig)


### PR DESCRIPTION
Fix bug that panel content does not update at all when changing to the story which does not have `withDeisgns` decorator nor `design` parameters.

Fix #14 

Tests in live example: <https://storybook-addon-designs-git-fix-addon-panel-persist.pocka.now.sh/?path=/story/tests-issues-14--do-not-persist-addon-panel-step-1>