### PR TITLE
`offscreen` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support private Figma files. (PR: [#33](https://github.com/pocka/storybook-addon-designs/pull/33))
+- `offscreen` option. (PR: [#40](https://github.com/pocka/storybook-addon-designs/pull/40))
 
 ## [5.2.0] - 2020-02-01
 

--- a/packages/examples/stories/tests/issues/39/index.stories.js
+++ b/packages/examples/stories/tests/issues/39/index.stories.js
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import { config, withDesign } from 'storybook-addon-designs'
+
+import { Button } from '../../../Button'
+
+export default {
+  title: 'Tests/Issues/#39',
+  decorators: [withDesign]
+}
+
+export const doNotRenderInactiveTab = () => <Button>Button</Button>
+
+doNotRenderInactiveTab.story = {
+  parameters: {
+    design: config([
+      {
+        type: 'figma',
+        name: 'Tab1',
+        url:
+          'https://www.figma.com/file/Klm6pxIZSaJFiOMX5FpTul9F/storybook-addon-designs-sample'
+      },
+      {
+        type: 'figma',
+        name: 'Tab2',
+        url:
+          'https://www.figma.com/file/Klm6pxIZSaJFiOMX5FpTul9F/storybook-addon-designs-sample?node-id=2%3A5'
+      }
+    ])
+  }
+}

--- a/packages/storybook-addon-designs/src/config.ts
+++ b/packages/storybook-addon-designs/src/config.ts
@@ -10,6 +10,12 @@ export interface ConfigBase {
    * A name of the tab.
    */
   name?: string
+
+  /**
+   * Whether to render a tab content when the tab is inactive.
+   * @default true
+   */
+  offscreen?: boolean
 }
 
 /**

--- a/packages/storybook-addon-designs/src/config.ts
+++ b/packages/storybook-addon-designs/src/config.ts
@@ -13,6 +13,7 @@ export interface ConfigBase {
 
   /**
    * Whether to render a tab content when the tab is inactive.
+   * This option is available only when there are more than 2 designs for a story.
    * @default true
    */
   offscreen?: boolean

--- a/packages/storybook-addon-designs/src/register/components/Tabs.tsx
+++ b/packages/storybook-addon-designs/src/register/components/Tabs.tsx
@@ -1,0 +1,30 @@
+/** @jsx jsx */
+import { FC, ReactNode, useState } from 'react'
+import { jsx } from '@storybook/theming'
+
+import { Tabs as SbTabs } from '@storybook/components'
+
+export interface Tab {
+  id: string
+  name: string
+  content: ReactNode
+  offscreen: boolean
+}
+
+export interface TabsProps {
+  tabs: readonly Tab[]
+}
+
+export const Tabs: FC<TabsProps> = ({ tabs }) => {
+  const [selected, setSelected] = useState(tabs[0].id)
+
+  return (
+    <SbTabs absolute selected={selected} actions={{ onSelect: setSelected }}>
+      {tabs.map(tab => (
+        <div key={tab.id} id={tab.id} title={tab.name}>
+          {tab.offscreen || selected === tab.id ? tab.content : null}
+        </div>
+      ))}
+    </SbTabs>
+  )
+}


### PR DESCRIPTION
Close #39 

Added `offscreen` option so users can control whether the tab content is rendered when the tab is not active. This option is always `false` regardless of the user input value when `type: "figma"`.