### PR TITLE
Export consistent PARAM_KEY as the @storybook/addons

### DIFF
--- a/packages/storybook-addon-designs/src/addon.ts
+++ b/packages/storybook-addon-designs/src/addon.ts
@@ -18,4 +18,4 @@ export const Events = {
 /**
  * A key of story parameters.
  */
-export const ParameterName = 'design'
+export const PARAM_KEY = 'design'

--- a/packages/storybook-addon-designs/src/index.ts
+++ b/packages/storybook-addon-designs/src/index.ts
@@ -1,6 +1,6 @@
 import addons, { makeDecorator, StoryWrapper } from '@storybook/addons'
 
-import { Events, ParameterName } from './addon'
+import { Events, PARAM_KEY } from './addon'
 import { Config } from './config'
 
 const wrapper: StoryWrapper = (getStory, context, { parameters }) => {
@@ -13,7 +13,7 @@ const wrapper: StoryWrapper = (getStory, context, { parameters }) => {
 
 export const withDesign = makeDecorator({
   name: 'withDesign',
-  parameterName: ParameterName,
+  parameterName: PARAM_KEY,
   skipIfNoParametersOrOptions: true,
   wrapper
 })
@@ -22,6 +22,8 @@ export const withDesign = makeDecorator({
  * Dumb function to ensure typings or enchance IDE auto completion.
  */
 export const config = (c: Config | Config[]) => c
+
+export { PARAM_KEY };
 
 if (module && module.hot && module.hot.decline) {
   module.hot.decline()

--- a/packages/storybook-addon-designs/src/index.ts
+++ b/packages/storybook-addon-designs/src/index.ts
@@ -23,7 +23,7 @@ export const withDesign = makeDecorator({
  */
 export const config = (c: Config | Config[]) => c
 
-export { PARAM_KEY };
+export { PARAM_KEY, Config };
 
 if (module && module.hot && module.hot.decline) {
   module.hot.decline()

--- a/packages/storybook-addon-designs/src/register/components/Wrapper.tsx
+++ b/packages/storybook-addon-designs/src/register/components/Wrapper.tsx
@@ -7,7 +7,7 @@ import { STORY_CHANGED } from '@storybook/core-events'
 import { Link, Placeholder, TabsState } from '@storybook/components'
 
 import { Config } from '../../config'
-import { Events, ParameterName } from '../../addon'
+import { Events, PARAM_KEY } from '../../addon'
 
 import { Figma } from './Figma'
 import { IFrame } from './IFrame'
@@ -31,7 +31,7 @@ export const Wrapper: SFC<Props> = ({ active, api, channel }) => {
     const onStoryChanged = (id: string) => {
       changeStory(id)
 
-      const cfg = api.getParameters(id, ParameterName)
+      const cfg = api.getParameters(id, PARAM_KEY)
 
       setConfig(prev => (cfg !== prev ? cfg : prev))
     }

--- a/packages/storybook-addon-designs/src/register/index.tsx
+++ b/packages/storybook-addon-designs/src/register/index.tsx
@@ -2,13 +2,14 @@
 import addons from '@storybook/addons'
 import { jsx } from '@storybook/theming'
 
-import { AddonName, PanelName } from '../addon'
+import { AddonName, PanelName, ParameterName } from '../addon'
 
 import { Wrapper } from './components/Wrapper'
 
 addons.register(AddonName, api => {
   addons.addPanel(PanelName, {
     title: 'Design',
+    paramKey: ParameterName,
     render({ active, key }) {
       return (
         <Wrapper

--- a/packages/storybook-addon-designs/src/register/index.tsx
+++ b/packages/storybook-addon-designs/src/register/index.tsx
@@ -2,14 +2,14 @@
 import addons from '@storybook/addons'
 import { jsx } from '@storybook/theming'
 
-import { AddonName, PanelName, ParameterName } from '../addon'
+import { AddonName, PanelName, PARAM_KEY } from '../addon'
 
 import { Wrapper } from './components/Wrapper'
 
 addons.register(AddonName, api => {
   addons.addPanel(PanelName, {
     title: 'Design',
-    paramKey: ParameterName,
+    paramKey: PARAM_KEY,
     render({ active, key }) {
       return (
         <Wrapper


### PR DESCRIPTION
I just opened this because it's a bit more disruptive than https://github.com/pocka/storybook-addon-designs/pull/54 but it would be good to have this consistent `PARAM_KEY` exported from the addons, and then we can just configure our stories with:
```
import { PARAM_KEY as ACTIONS_KEY } from '@storybook/addon-actions';
import { PARAM_KEY as KNOBS_KEY } from '@storybook/addon-knobs';
import { PARAM_KEY as DESIGN_KEY, config } from 'storybook-addon-designs';

...
  [ACTIONS_KEY]: { disabled: true },
  [KNOBS_KEY]: { disabled: true },
  [DESIGN_KEY]: config({
      type: 'figma',
      ...
  }),
```