### PR TITLE
Doc Blocks

### DIFF
--- a/packages/examples-tab/.storybook/main.js
+++ b/packages/examples-tab/.storybook/main.js
@@ -1,3 +1,5 @@
+const main = require('../../examples/.storybook/main')
+
 module.exports = {
   stories: [
     '../../examples/stories/**/*.stories.mdx',
@@ -12,7 +14,9 @@ module.exports = {
       }
     }
   ],
-  webpackFinal(config) {
+  webpackFinal(_config) {
+    const config = main.webpackFinal(_config)
+
     return {
       ...config,
       module: {

--- a/packages/examples/.storybook/main.js
+++ b/packages/examples/.storybook/main.js
@@ -1,8 +1,48 @@
+const path = require('path')
+
+const tsconfig = path.resolve(
+  __dirname,
+  '../../storybook-addon-designs/tsconfig.json'
+)
+
 module.exports = {
   stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.{js,jsx}'],
   addons: [
     'storybook-addon-designs',
     '@storybook/addon-docs',
     '@storybook/addon-storysource'
-  ]
+  ],
+  webpackFinal(config) {
+    return {
+      ...config,
+      module: {
+        ...config.module,
+        rules: [
+          ...config.module.rules,
+          {
+            test: /\.tsx?$/,
+            use: [
+              {
+                loader: 'ts-loader',
+                options: {
+                  configFile: tsconfig,
+                  transpileOnly: true
+                }
+              },
+              {
+                loader: 'react-docgen-typescript-loader',
+                options: {
+                  tsconfigPath: tsconfig
+                }
+              }
+            ]
+          }
+        ]
+      },
+      resolve: {
+        ...config.resolve,
+        extensions: [...config.resolve.extensions, '.ts', '.tsx']
+      }
+    }
+  }
 }

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -19,7 +19,9 @@
     "@storybook/react": "5.3.19",
     "@storybook/theming": "5.3.19",
     "babel-loader": "^8.0.5",
-    "storybook-addon-designs": "^5.3.0"
+    "react-docgen-typescript-loader": "^3.7.2",
+    "storybook-addon-designs": "^5.3.0",
+    "ts-loader": "^7.0.5"
   },
   "scripts": {
     "storybook": "start-storybook -p 6006 -s ../assets",

--- a/packages/examples/stories/docs/advanced/docs.mdx
+++ b/packages/examples/stories/docs/advanced/docs.mdx
@@ -117,7 +117,7 @@ import 'storybook-addon-designs/register-tab'
 
 ## Doc Blocks
 
-The addon provides React components for addon-docs, so you can embed design specs to your Docs like this:
+The addon provides React components for addon-docs, so you can embed design specs to your Docs:
 
 <Figma
   height="30%"
@@ -125,10 +125,4 @@ The addon provides React components for addon-docs, so you can embed design spec
   url="https://www.figma.com/file/Klm6pxIZSaJFiOMX5FpTul9F/storybook-addon-designs-sample"
 />
 
-<IFrame
-  height="50%"
-  collapsable
-  defaultCollapsed
-  placeholder="iframe embeds"
-  url="https://www.wikipedia.org"
-/>
+For more details, please refer to [Internal/Blocks/Common](/?path=/docs/internal-blocks-common--page).

--- a/packages/examples/stories/docs/advanced/docs.mdx
+++ b/packages/examples/stories/docs/advanced/docs.mdx
@@ -1,6 +1,8 @@
 import { Subtitle } from '@storybook/addon-docs/blocks'
 import { TabsState } from '@storybook/components'
 
+import { Figma, IFrame } from 'storybook-addon-designs/blocks'
+
 import { TabLink } from './TabLink'
 
 # Advanced usage
@@ -9,6 +11,7 @@ import { TabLink } from './TabLink'
 
 - [Embed multiple designs](#embed-multiple-designs)
 - [Render as tab instead of addon panel](#render-as-tab-instead-of-addon-panel)
+- [Doc Blocks](#doc-blocks)
 
 ## Embed multiple designs
 
@@ -111,3 +114,21 @@ import 'storybook-addon-designs/register-tab'
 
   </div></div>
 </TabsState>
+
+## Doc Blocks
+
+The addon provides React components for addon-docs, so you can embed design specs to your Docs like this:
+
+<Figma
+  height="30%"
+  collapsable
+  url="https://www.figma.com/file/Klm6pxIZSaJFiOMX5FpTul9F/storybook-addon-designs-sample"
+/>
+
+<IFrame
+  height="50%"
+  collapsable
+  defaultCollapsed
+  placeholder="iframe embeds"
+  url="https://www.wikipedia.org"
+/>

--- a/packages/examples/stories/internal/blocks/0.common.stories.mdx
+++ b/packages/examples/stories/internal/blocks/0.common.stories.mdx
@@ -1,0 +1,72 @@
+import { Meta, Props, Source } from '@storybook/addon-docs/blocks'
+import {
+  DocBlockBase,
+  IFrame
+} from '../../../../storybook-addon-designs/src/blocks'
+
+<Meta title="Internal/Blocks/Common" />
+
+# Doc Block
+
+Stories here demonstrates Doc Block specific props and behaviors.
+These props and behaviors are same among every Design Doc Blocks.
+
+<Props of={DocBlockBase} />
+
+# Variants
+
+<br />
+
+## Change heights
+
+You can specify block's height by setting `height` prop.
+Values with percentage (e.g. `50%`) is computed based on the block's width, think as ratio to a width.
+
+<Source language="jsx" code={`<IFrame url="https://www.wikipedia.org" height="100%" defaultCollapsed />`}/>
+<IFrame url="https://www.wikipedia.org" height="100%" defaultCollapsed />
+
+---
+
+<Source language="jsx" code={`<IFrame url="https://www.wikipedia.org" height="200%" defaultCollapsed />`}/>
+<IFrame url="https://www.wikipedia.org" height="200%" defaultCollapsed />
+
+---
+
+<Source language="jsx" code={`<IFrame url="https://www.wikipedia.org" height="50%" defaultCollapsed />`}/>
+<IFrame url="https://www.wikipedia.org" height="50%" defaultCollapsed />
+
+## Collapse / Expand
+
+Design Doc Blocks has an ability to toggle collapse / expand itself, which is set to `true` by default.
+You can turn off the feature by passing `false` to `collapsable` prop or change the default state with `defaultCollapsed` prop.
+
+<Source language="jsx" code={`<IFrame url="https://www.wikipedia.org" height={100} collapsable={false} />`}/>
+<IFrame url="https://www.wikipedia.org" height={100} collapsable={false} />
+
+---
+
+<Source language="jsx" code={`<IFrame url="https://www.wikipedia.org" height={100} defaultCollapsed />`}/>
+<IFrame url="https://www.wikipedia.org" height={100} defaultCollapsed />
+
+Also, you can customize the text shown when the block is collapsed with `placeholder` prop.
+
+<Source language="jsx" code={`<IFrame
+\r  url="https://www.wikipedia.org"
+\r  height={100}
+\r  defaultCollapsed
+\r  placeholder="Foo"
+/>`}/>
+<IFrame
+  url="https://www.wikipedia.org"
+  height={100}
+  defaultCollapsed
+  placeholder="Foo"
+/>
+
+## Open in new tab
+
+By default, Design Doc Blocks show an `Open in new tab` to allow users to open the embed content in a new tab.
+You can disable it by passing `false` to `showLink` prop.
+
+<Source language="jsx" code={`<IFrame url="https://www.wikipedia.org" height={100} showLink={false} />`}/>
+<IFrame url="https://www.wikipedia.org" height={100} showLink={false} />

--- a/packages/examples/stories/internal/blocks/1.design.stories.mdx
+++ b/packages/examples/stories/internal/blocks/1.design.stories.mdx
@@ -1,0 +1,39 @@
+import {
+  Meta,
+  Preview,
+  Props,
+  Source,
+  Story,
+} from '@storybook/addon-docs/blocks'
+import { Design } from '../../../../storybook-addon-designs/src/blocks'
+
+<Meta title="Internal/Blocks/Design" />
+
+# Design Doc Block
+
+Design Doc Block takes a story ID and shows design embeds based on the story's parameter.
+All you need to do is refer to a story you want to display.
+
+<Props of={Design} />
+
+<Preview>
+  <Story
+    name="foo"
+    parameters={{
+      design: {
+        type: 'figma',
+        url:
+          'https://www.figma.com/file/Klm6pxIZSaJFiOMX5FpTul9F/storybook-addon-designs-sample',
+      },
+    }}
+  >
+    <button>Button</button>
+  </Story>
+</Preview>
+
+<Design storyId="internal-blocks-design--foo" />
+
+<Source
+  language="jsx"
+  code={`<Design storyId="internal-blocks-design--foo" />`}
+/>

--- a/packages/examples/stories/internal/blocks/figma.stories.mdx
+++ b/packages/examples/stories/internal/blocks/figma.stories.mdx
@@ -1,0 +1,9 @@
+import { Meta, Props } from '@storybook/addon-docs/blocks'
+import { Figma } from '../../../../storybook-addon-designs/src/blocks'
+
+<Meta title="Internal/Blocks/Figma" />
+
+# Figma Block
+
+<Figma url="https://www.figma.com/file/Klm6pxIZSaJFiOMX5FpTul9F/storybook-addon-designs-sample" />
+<Props of={Figma} />

--- a/packages/examples/stories/internal/blocks/iframe.stories.mdx
+++ b/packages/examples/stories/internal/blocks/iframe.stories.mdx
@@ -1,0 +1,9 @@
+import { Meta, Props } from '@storybook/addon-docs/blocks'
+import { IFrame } from '../../../../storybook-addon-designs/src/blocks'
+
+<Meta title="Internal/Blocks/IFrame" />
+
+# iframe Block
+
+<IFrame url="https://www.wikipedia.org" />
+<Props of={IFrame} />

--- a/packages/examples/stories/internal/blocks/image.stories.mdx
+++ b/packages/examples/stories/internal/blocks/image.stories.mdx
@@ -1,0 +1,10 @@
+import { Meta, Props } from '@storybook/addon-docs/blocks'
+import { Image } from '../../../../storybook-addon-designs/src/blocks'
+import sampleImage from '@storybook-addon-designs/assets/sample.png'
+
+<Meta title="Internal/Blocks/Image" />
+
+# Image Block
+
+<Image url={sampleImage} />
+<Props of={Image} />

--- a/packages/examples/stories/internal/blocks/pdf.stories.mdx
+++ b/packages/examples/stories/internal/blocks/pdf.stories.mdx
@@ -1,0 +1,10 @@
+import { Meta, Props } from '@storybook/addon-docs/blocks'
+import { PDF } from '../../../../storybook-addon-designs/src/blocks'
+import samplePdf from '@storybook-addon-designs/assets/sample.pdf'
+
+<Meta title="Internal/Blocks/PDF" />
+
+# PDF Block
+
+<PDF url={samplePdf} />
+<Props of={PDF} />

--- a/packages/storybook-addon-designs/blocks.js
+++ b/packages/storybook-addon-designs/blocks.js
@@ -1,0 +1,1 @@
+export * from './esm/blocks'

--- a/packages/storybook-addon-designs/package.json
+++ b/packages/storybook-addon-designs/package.json
@@ -18,6 +18,8 @@
   ],
   "devDependencies": {
     "@storybook/addons": "^5.3.19",
+    "@storybook/addon-docs": "^5.3.19",
+    "@storybook/client-api": "^5.3.19",
     "@storybook/components": "^5.3.19",
     "@storybook/core-events": "^5.3.19",
     "@storybook/theming": "^5.3.19",

--- a/packages/storybook-addon-designs/src/blocks.tsx
+++ b/packages/storybook-addon-designs/src/blocks.tsx
@@ -149,7 +149,7 @@ export const IFrame: FC<Omit<config.IFrameConfig, 'type'> &
 )
 
 // Image would do shadowing the native variable (Image constructor, which creates
-// HTMLImageElement), but I think it doesn't matter since there is less change to
+// HTMLImageElement), but I think it doesn't matter since there is less chance to
 // use Image constructor in MDX.
 export const Image: FC<Omit<config.ImageConfig, 'type'> &
   BlocksCommonProps> = ({ placeholder, ...props }) => (

--- a/packages/storybook-addon-designs/src/blocks.tsx
+++ b/packages/storybook-addon-designs/src/blocks.tsx
@@ -1,0 +1,99 @@
+/** @jsx jsx */
+import { CSSProperties, FC, useState } from 'react'
+import { ActionBar, Placeholder } from '@storybook/components'
+import * as Html from '@storybook/components/html'
+import { jsx, styled } from '@storybook/theming'
+
+import { Figma as FigmaInternal } from './register/components/Figma'
+import { IFrame as IFrameInternal } from './register/components/IFrame'
+
+import * as config from './config'
+
+const Wrapper = styled.div<BlocksCommonProps & { collapsed: boolean }>(
+  ({ theme, height = '60%', collapsed }) => `
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding: 0;
+  padding-top: ${
+    collapsed ? '3em' : typeof height == 'string' ? height : height + 'px'
+  };
+  margin: 25px 0 40px;
+  border: 1px solid ${theme.appBorderColor};
+
+  border-radius: ${theme.appBorderRadius}px;
+  box-shadow:
+    ${
+      theme.base === 'light'
+        ? 'rgba(0, 0, 0, 0.10) 0 1px 3px 0'
+        : 'rgba(0, 0, 0, 0.20) 0 2px 5px 0'
+    };
+`
+)
+
+const CollapsedText = styled(Placeholder)`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+
+  transform: translate(-50%, -50%);
+`
+
+export interface BlocksCommonProps {
+  className?: string
+  style?: CSSProperties
+
+  height?: string | number
+
+  collapsable?: boolean
+  defaultCollapsed?: boolean
+  placeholder?: string
+}
+
+const DocBlockBase: FC<BlocksCommonProps> = ({
+  children,
+  collapsable,
+  defaultCollapsed,
+  placeholder = 'Design spec (collapsed)',
+  ...rest
+}) => {
+  const [collapsed, setCollapsed] = useState(!!defaultCollapsed)
+
+  return (
+    <Html.ResetWrapper>
+      <Wrapper collapsed={collapsed} {...rest}>
+        {collapsed ? <CollapsedText>{placeholder}</CollapsedText> : children}
+        {collapsable && (
+          <ActionBar
+            actionItems={[
+              {
+                title: collapsed ? 'Show' : 'Hide',
+                onClick: () => setCollapsed((v) => !v),
+              },
+              'url' in rest && {
+                title: 'Open in new tab',
+                onClick: () => window.open((rest as any).url, '_blank'),
+              },
+            ]}
+          />
+        )}
+      </Wrapper>
+    </Html.ResetWrapper>
+  )
+}
+
+export const Figma: FC<Omit<config.FigmaConfig, 'type'> & BlocksCommonProps> = (
+  props
+) => (
+  <DocBlockBase {...props}>
+    <FigmaInternal config={{ type: 'figma', ...props }} />
+  </DocBlockBase>
+)
+
+export const IFrame: FC<
+  Omit<config.IFrameConfig, 'type'> & BlocksCommonProps
+> = (props) => (
+  <DocBlockBase {...props}>
+    <IFrameInternal config={props} />
+  </DocBlockBase>
+)

--- a/packages/storybook-addon-designs/src/blocks.tsx
+++ b/packages/storybook-addon-designs/src/blocks.tsx
@@ -40,60 +40,108 @@ const CollapsedText = styled(Placeholder)`
 `
 
 export interface BlocksCommonProps {
+  /**
+   * **Doc Block Props**
+   *
+   * A `class` prop passed down to embed wrapper.
+   */
   className?: string
+  /**
+   * **Doc Block Props**
+   *
+   * A `style` passed down to embed wrapper.
+   */
   style?: CSSProperties
 
+  /**
+   * **Doc Block Props**
+   *
+   * Height of the block. Numbers will be converted into pixels.
+   * Relative value (%) is based on width of the block.
+   */
   height?: string | number
 
+  /**
+   * **Doc Block Props**
+   *
+   * Whether to allow the block to toggle collapse/expand.
+   * @default true
+   */
   collapsable?: boolean
+
+  /**
+   * **Doc Block Props**
+   *
+   * Render the block with collapsed initially?
+   * Available when `collapsable` is set to `true`.
+   * @default false
+   */
   defaultCollapsed?: boolean
+
+  /**
+   * **Doc Block Props**
+   *
+   * Placeholder text shown when the block is collapsed.
+   * Default value differs by a type of the block (e.g. "Design (Figma)").
+   */
   placeholder?: string
+
+  /**
+   * **Doc Block Props**
+   *
+   * Whether to show an "Open in new tab" button.
+   * @default true
+   */
+  showLink?: boolean
 }
 
-const DocBlockBase: FC<BlocksCommonProps> = ({
+export const DocBlockBase: FC<BlocksCommonProps> = ({
   children,
-  collapsable,
-  defaultCollapsed,
-  placeholder = 'Design spec (collapsed)',
+  collapsable = true,
+  defaultCollapsed = false,
+  placeholder,
+  showLink = true,
   ...rest
 }) => {
   const [collapsed, setCollapsed] = useState(!!defaultCollapsed)
 
+  const showOpenInNewTab = showLink && 'url' in rest
+
   return (
     <Html.ResetWrapper>
-      <Wrapper collapsed={collapsed} {...rest}>
-        {collapsed ? <CollapsedText>{placeholder}</CollapsedText> : children}
-        {collapsable && (
-          <ActionBar
-            actionItems={[
-              {
-                title: collapsed ? 'Show' : 'Hide',
-                onClick: () => setCollapsed((v) => !v),
-              },
-              'url' in rest && {
-                title: 'Open in new tab',
-                onClick: () => window.open((rest as any).url, '_blank'),
-              },
-            ]}
-          />
+      <Wrapper collapsed={collapsable && collapsed} {...rest}>
+        {collapsable && collapsed ? (
+          <CollapsedText>{placeholder}</CollapsedText>
+        ) : (
+          children
         )}
+        <ActionBar
+          actionItems={[
+            collapsable && {
+              title: collapsed ? 'Show' : 'Hide',
+              onClick: () => setCollapsed(v => !v)
+            },
+            showOpenInNewTab && {
+              title: 'Open in new tab',
+              onClick: () => window.open((rest as any).url, '_blank')
+            }
+          ].filter(Boolean)}
+        />
       </Wrapper>
     </Html.ResetWrapper>
   )
 }
 
-export const Figma: FC<Omit<config.FigmaConfig, 'type'> & BlocksCommonProps> = (
-  props
-) => (
-  <DocBlockBase {...props}>
+export const Figma: FC<Omit<config.FigmaConfig, 'type'> &
+  BlocksCommonProps> = ({ placeholder, ...props }) => (
+  <DocBlockBase placeholder={placeholder ?? 'Design (Figma)'} {...props}>
     <FigmaInternal config={{ type: 'figma', ...props }} />
   </DocBlockBase>
 )
 
-export const IFrame: FC<
-  Omit<config.IFrameConfig, 'type'> & BlocksCommonProps
-> = (props) => (
-  <DocBlockBase {...props}>
+export const IFrame: FC<Omit<config.IFrameConfig, 'type'> &
+  BlocksCommonProps> = ({ placeholder, ...props }) => (
+  <DocBlockBase placeholder={placeholder ?? 'Design (iframe)'} {...props}>
     <IFrameInternal config={props} />
   </DocBlockBase>
 )

--- a/packages/storybook-addon-designs/src/blocks.tsx
+++ b/packages/storybook-addon-designs/src/blocks.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
-import { CSSProperties, FC, useState } from 'react'
+import { CSSProperties, FC, useContext, useState } from 'react'
+import { DocsContext } from '@storybook/addon-docs/blocks'
 import { ActionBar, Placeholder } from '@storybook/components'
 import * as Html from '@storybook/components/html'
 import { jsx, styled } from '@storybook/theming'
@@ -8,8 +9,10 @@ import { Figma as FigmaInternal } from './register/components/Figma'
 import { IFrame as IFrameInternal } from './register/components/IFrame'
 import { ImagePreview } from './register/components/Image'
 import { Pdf as PDFInternal } from './register/components/Pdf'
+import { Wrapper as WrapperInternal } from './register/components/Wrapper'
 
 import * as config from './config'
+import { ParameterName } from './addon'
 
 const Wrapper = styled.div<BlocksCommonProps & { collapsed: boolean }>(
   ({ theme, height = '60%', collapsed }) => `
@@ -121,12 +124,12 @@ export const DocBlockBase: FC<BlocksCommonProps> = ({
           actionItems={[
             collapsable && {
               title: collapsed ? 'Show' : 'Hide',
-              onClick: () => setCollapsed(v => !v)
+              onClick: () => setCollapsed((v) => !v),
             },
             showOpenInNewTab && {
               title: 'Open in new tab',
-              onClick: () => window.open((rest as any).url, '_blank')
-            }
+              onClick: () => window.open((rest as any).url, '_blank'),
+            },
           ].filter(Boolean)}
         />
       </Wrapper>
@@ -134,15 +137,17 @@ export const DocBlockBase: FC<BlocksCommonProps> = ({
   )
 }
 
-export const Figma: FC<Omit<config.FigmaConfig, 'type'> &
-  BlocksCommonProps> = ({ placeholder, ...props }) => (
+export const Figma: FC<
+  Omit<config.FigmaConfig, 'type'> & BlocksCommonProps
+> = ({ placeholder, ...props }) => (
   <DocBlockBase placeholder={placeholder ?? 'Design (Figma)'} {...props}>
     <FigmaInternal config={{ type: 'figma', ...props }} />
   </DocBlockBase>
 )
 
-export const IFrame: FC<Omit<config.IFrameConfig, 'type'> &
-  BlocksCommonProps> = ({ placeholder, ...props }) => (
+export const IFrame: FC<
+  Omit<config.IFrameConfig, 'type'> & BlocksCommonProps
+> = ({ placeholder, ...props }) => (
   <DocBlockBase placeholder={placeholder ?? 'Design (iframe)'} {...props}>
     <IFrameInternal config={props} />
   </DocBlockBase>
@@ -151,8 +156,9 @@ export const IFrame: FC<Omit<config.IFrameConfig, 'type'> &
 // Image would do shadowing the native variable (Image constructor, which creates
 // HTMLImageElement), but I think it doesn't matter since there is less chance to
 // use Image constructor in MDX.
-export const Image: FC<Omit<config.ImageConfig, 'type'> &
-  BlocksCommonProps> = ({ placeholder, ...props }) => (
+export const Image: FC<
+  Omit<config.ImageConfig, 'type'> & BlocksCommonProps
+> = ({ placeholder, ...props }) => (
   <DocBlockBase placeholder={placeholder ?? 'Design (Image)'} {...props}>
     <ImagePreview config={{ type: 'image', ...props }} />
   </DocBlockBase>
@@ -166,3 +172,38 @@ export const PDF: FC<Omit<config.PdfConfig, 'type'> & BlocksCommonProps> = ({
     <PDFInternal config={{ type: 'pdf', ...props }} />
   </DocBlockBase>
 )
+
+const AbsoluteLocater = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+
+  overflow: auto;
+`
+
+export interface DesignProps {
+  /**
+   * An ID of the story that has `design` parameter to use for rendering.
+   */
+  storyId: string
+}
+
+export const Design: FC<DesignProps & Omit<BlocksCommonProps, 'showLink'>> = ({
+  storyId,
+  placeholder,
+  ...rest
+}) => {
+  const { storyStore } = useContext(DocsContext)
+
+  const story = storyStore?.fromId(storyId)
+
+  return (
+    <DocBlockBase placeholder={placeholder ?? 'Design'} {...rest}>
+      <AbsoluteLocater>
+        <WrapperInternal config={story?.parameters?.[ParameterName]} />
+      </AbsoluteLocater>
+    </DocBlockBase>
+  )
+}

--- a/packages/storybook-addon-designs/src/blocks.tsx
+++ b/packages/storybook-addon-designs/src/blocks.tsx
@@ -6,6 +6,8 @@ import { jsx, styled } from '@storybook/theming'
 
 import { Figma as FigmaInternal } from './register/components/Figma'
 import { IFrame as IFrameInternal } from './register/components/IFrame'
+import { ImagePreview } from './register/components/Image'
+import { Pdf as PDFInternal } from './register/components/Pdf'
 
 import * as config from './config'
 
@@ -143,5 +145,24 @@ export const IFrame: FC<Omit<config.IFrameConfig, 'type'> &
   BlocksCommonProps> = ({ placeholder, ...props }) => (
   <DocBlockBase placeholder={placeholder ?? 'Design (iframe)'} {...props}>
     <IFrameInternal config={props} />
+  </DocBlockBase>
+)
+
+// Image would do shadowing the native variable (Image constructor, which creates
+// HTMLImageElement), but I think it doesn't matter since there is less change to
+// use Image constructor in MDX.
+export const Image: FC<Omit<config.ImageConfig, 'type'> &
+  BlocksCommonProps> = ({ placeholder, ...props }) => (
+  <DocBlockBase placeholder={placeholder ?? 'Design (Image)'} {...props}>
+    <ImagePreview config={{ type: 'image', ...props }} />
+  </DocBlockBase>
+)
+
+export const PDF: FC<Omit<config.PdfConfig, 'type'> & BlocksCommonProps> = ({
+  placeholder,
+  ...props
+}) => (
+  <DocBlockBase placeholder={placeholder ?? 'Design (PDF)'} {...props}>
+    <PDFInternal config={{ type: 'pdf', ...props }} />
   </DocBlockBase>
 )

--- a/packages/storybook-addon-designs/src/lib.d.ts
+++ b/packages/storybook-addon-designs/src/lib.d.ts
@@ -3,6 +3,18 @@ declare module '!!file-loader!*' {
   export default path
 }
 
+// TODO: Remove these Storybook defs after SB@6 stable was released
+declare module '@storybook/addon-docs/blocks' {
+  import { Context } from 'react'
+  import { StoryStore } from '@storybook/client-api'
+
+  interface ContextValue {
+    storyStore?: StoryStore
+  }
+
+  export const DocsContext: Context<ContextValue>
+}
+
 declare module '@storybook/components' {
   import { ComponentType } from 'react'
 
@@ -49,7 +61,7 @@ declare module 'react-pdf/dist/entry.webpack' {
     PDFDocumentProxy,
     PDFPageProxy,
     PDFRenderTextLayer,
-    PDFTreeNode
+    PDFTreeNode,
   } from 'pdfjs-dist'
 
   export const pdfjs: any

--- a/packages/storybook-addon-designs/src/register/components/Wrapper.tsx
+++ b/packages/storybook-addon-designs/src/register/components/Wrapper.tsx
@@ -1,13 +1,10 @@
 /** @jsx jsx */
-import { Fragment, SFC, useEffect, useState } from 'react'
+import { Fragment, SFC } from 'react'
 import { jsx } from '@storybook/theming'
-import addons from '@storybook/addons'
-import { STORY_CHANGED } from '@storybook/core-events'
 
-import { Link, Placeholder, TabsState } from '@storybook/components'
+import { Link, Placeholder } from '@storybook/components'
 
 import { Config } from '../../config'
-import { Events, ParameterName } from '../../addon'
 
 import { Figma } from './Figma'
 import { IFrame } from './IFrame'
@@ -17,39 +14,10 @@ import { Pdf } from './Pdf'
 import { Tab, Tabs } from './Tabs'
 
 interface Props {
-  channel: ReturnType<typeof addons['getChannel']>
-
-  api: any
-
-  active: boolean
+  config?: Config | Config[]
 }
 
-export const Wrapper: SFC<Props> = ({ active, api, channel }) => {
-  const [config, setConfig] = useState<Config | Config[]>()
-  const [storyId, changeStory] = useState<string>()
-
-  useEffect(() => {
-    const onStoryChanged = (id: string) => {
-      changeStory(id)
-
-      const cfg = api.getParameters(id, ParameterName)
-
-      setConfig(prev => (cfg !== prev ? cfg : prev))
-    }
-
-    channel.on(Events.UpdateConfig, setConfig)
-    channel.on(STORY_CHANGED, onStoryChanged)
-
-    return () => {
-      channel.removeListener(Events.UpdateConfig, setConfig)
-      channel.removeListener(STORY_CHANGED, onStoryChanged)
-    }
-  }, [])
-
-  if (!active) {
-    return null
-  }
-
+export const Wrapper: SFC<Props> = ({ config }) => {
   if (!config || ('length' in config && config.length === 0)) {
     return (
       <Placeholder>
@@ -98,7 +66,7 @@ export const Wrapper: SFC<Props> = ({ active, api, channel }) => {
         case 'image':
           return {
             ...meta,
-            content: <ImagePreview key={storyId} config={cfg} />
+            content: <ImagePreview config={cfg} />
           }
         case 'link':
           return {
@@ -131,10 +99,10 @@ export const Wrapper: SFC<Props> = ({ active, api, channel }) => {
   )
 
   if (tabs.length === 1) {
-    return <div key={storyId}>{tabs[0].content}</div>
+    return <div>{tabs[0].content}</div>
   }
 
-  return <Tabs key={storyId} tabs={tabs} />
+  return <Tabs tabs={tabs} />
 }
 
 export default Wrapper

--- a/packages/storybook-addon-designs/src/register/containers/Wrapper.tsx
+++ b/packages/storybook-addon-designs/src/register/containers/Wrapper.tsx
@@ -1,0 +1,51 @@
+/** @jsx jsx */
+import { Fragment, SFC, useEffect, useState } from 'react'
+import { jsx } from '@storybook/theming'
+import addons from '@storybook/addons'
+import { STORY_CHANGED } from '@storybook/core-events'
+
+import { Link, Placeholder, TabsState } from '@storybook/components'
+
+import { Config } from '../../config'
+import { Events, ParameterName } from '../../addon'
+
+import { Wrapper as Pure } from '../components/Wrapper'
+
+interface Props {
+  channel: ReturnType<typeof addons['getChannel']>
+
+  api: any
+
+  active: boolean
+}
+
+export const Wrapper: SFC<Props> = ({ active, api, channel }) => {
+  const [config, setConfig] = useState<Config | Config[]>()
+  const [storyId, changeStory] = useState<string>()
+
+  useEffect(() => {
+    const onStoryChanged = (id: string) => {
+      changeStory(id)
+
+      const cfg = api.getParameters(id, ParameterName)
+
+      setConfig(prev => (cfg !== prev ? cfg : prev))
+    }
+
+    channel.on(Events.UpdateConfig, setConfig)
+    channel.on(STORY_CHANGED, onStoryChanged)
+
+    return () => {
+      channel.removeListener(Events.UpdateConfig, setConfig)
+      channel.removeListener(STORY_CHANGED, onStoryChanged)
+    }
+  }, [])
+
+  if (!active) {
+    return null
+  }
+
+  return <Pure key={storyId} config={config} />
+}
+
+export default Wrapper

--- a/packages/storybook-addon-designs/src/register/index.tsx
+++ b/packages/storybook-addon-designs/src/register/index.tsx
@@ -4,7 +4,7 @@ import { jsx } from '@storybook/theming'
 
 import { AddonName, PanelName, ParameterName } from '../addon'
 
-import { Wrapper } from './components/Wrapper'
+import { Wrapper } from './containers/Wrapper'
 
 export default function register(renderTarget: 'panel' | 'tab') {
   addons.register(AddonName, api => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3021,6 +3021,18 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
+"@webpack-contrib/schema-utils@^1.0.0-beta.0":
+  version "1.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@webpack-contrib/schema-utils/-/schema-utils-1.0.0-beta.0.tgz#bf9638c9464d177b48209e84209e23bee2eb4f65"
+  integrity sha512-LonryJP+FxQQHsjGBi6W786TQB1Oym+agTpY0c+Kj8alnIw+DLUJb6SI8Y1GHGhLCH1yPRrucjObUmxNICQ1pg==
+  dependencies:
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chalk "^2.3.2"
+    strip-ansi "^4.0.0"
+    text-table "^0.2.0"
+    webpack-log "^1.1.2"
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -4316,7 +4328,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -5069,6 +5081,14 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+d@1, d@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
+  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
+  dependencies:
+    es5-ext "^0.10.50"
+    type "^1.0.1"
+
 dargs@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
@@ -5542,6 +5562,15 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
+enhanced-resolve@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.2.0.tgz#5d43bda4a0fd447cb0ebbe71bef8deff8805ad0d"
+  integrity sha512-S7eiFb/erugyd1rLb6mQ3Vuq+EXHv5cpCkNqqIkYkBgN2QdFnyCZzFBleqwGEx4lgNGYij81BWnCrFNK7vxvjQ==
+  dependencies:
+    graceful-fs "^4.1.2"
+    memory-fs "^0.5.0"
+    tapable "^1.0.0"
+
 enhanced-resolve@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz#2937e2b8066cd0fe7ce0990a98f0d71a35189f66"
@@ -5634,10 +5663,28 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es5-ext@^0.10.35, es5-ext@^0.10.50:
+  version "0.10.53"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
+  integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
+  dependencies:
+    es6-iterator "~2.0.3"
+    es6-symbol "~3.1.3"
+    next-tick "~1.0.0"
+
 es5-shim@^4.5.13:
   version "4.5.14"
   resolved "https://registry.yarnpkg.com/es5-shim/-/es5-shim-4.5.14.tgz#90009e1019d0ea327447cb523deaff8fe45697ef"
   integrity sha512-7SwlpL+2JpymWTt8sNLuC2zdhhc+wrfe5cMPI2j0o6WsPdfAiPwmFy2f0AocPB4RQVBOZ9kNTgi5YF7TdhkvEg==
+
+es6-iterator@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
 
 es6-promise@^4.0.3:
   version "4.2.8"
@@ -5655,6 +5702,14 @@ es6-shim@^0.35.5:
   version "0.35.5"
   resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.5.tgz#46f59dc0a84a1c5029e8ff1166ca0a902077a9ab"
   integrity sha512-E9kK/bjtCQRpN1K28Xh4BlmP8egvZBGJJ+9GtnzOwt7mdqtrjHFuVGr7QJfdjBIKqrlU5duPf3pCBoDrkjVYFg==
+
+es6-symbol@^3.1.1, es6-symbol@~3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
+  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
+  dependencies:
+    d "^1.0.1"
+    ext "^1.1.2"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -5809,6 +5864,13 @@ express@^4.17.0:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
+
+ext@^1.1.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ext/-/ext-1.4.0.tgz#89ae7a07158f79d35517882904324077e4379244"
+  integrity sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==
+  dependencies:
+    type "^2.0.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -7900,7 +7962,7 @@ loader-utils@2.0.0, loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-loader-utils@^1.0.0, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.0.0, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -8006,6 +8068,21 @@ lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+log-symbols@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
+  dependencies:
+    chalk "^2.0.1"
+
+loglevelnext@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/loglevelnext/-/loglevelnext-1.0.5.tgz#36fc4f5996d6640f539ff203ba819641680d75a2"
+  integrity sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==
+  dependencies:
+    es6-symbol "^3.1.1"
+    object.assign "^4.1.0"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -8361,7 +8438,7 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2:
+micromatch@^4.0.0, micromatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
   integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
@@ -8656,6 +8733,11 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
+
+next-tick@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
+  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -10032,6 +10114,20 @@ react-dev-utils@^9.0.0:
     sockjs-client "1.4.0"
     strip-ansi "5.2.0"
     text-table "0.2.0"
+
+react-docgen-typescript-loader@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript-loader/-/react-docgen-typescript-loader-3.7.2.tgz#45cb2305652c0602767242a8700ad1ebd66bbbbd"
+  integrity sha512-fNzUayyUGzSyoOl7E89VaPKJk9dpvdSgyXg81cUkwy0u+NBvkzQG3FC5WBIlXda0k/iaxS+PWi+OC+tUiGxzPA==
+  dependencies:
+    "@webpack-contrib/schema-utils" "^1.0.0-beta.0"
+    loader-utils "^1.2.3"
+    react-docgen-typescript "^1.15.0"
+
+react-docgen-typescript@^1.15.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.18.0.tgz#7f43b186b0228364cc6583231c3be09fbd3eb5e3"
+  integrity sha512-nY4bXz44tLzXBVF+cyaL/gZsMxlmYVICaEIXFF4EqvD8PEN1+zL+IgaQ1mNfJ6Zq8jUFAeXDo1Ds7ylxWZtjXQ==
 
 react-docgen@^5.0.0:
   version "5.3.0"
@@ -11710,7 +11806,7 @@ text-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
   integrity sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==
 
-text-table@0.2.0:
+text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
@@ -11900,6 +11996,17 @@ ts-dedent@^1.1.0:
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-1.1.1.tgz#68fad040d7dbd53a90f545b450702340e17d18f3"
   integrity sha512-UGTRZu1evMw4uTPyYF66/KFd22XiU+jMaIuHrkIHQ2GivAXVlLV0v/vHrpOuTRf9BmpNHi/SO7Vd0rLu0y57jg==
 
+ts-loader@^7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-7.0.5.tgz#789338fb01cb5dc0a33c54e50558b34a73c9c4c5"
+  integrity sha512-zXypEIT6k3oTc+OZNx/cqElrsbBtYqDknf48OZos0NQ3RTt045fBIU8RRSu+suObBzYB355aIPGOe/3kj9h7Ig==
+  dependencies:
+    chalk "^2.3.0"
+    enhanced-resolve "^4.0.0"
+    loader-utils "^1.0.2"
+    micromatch "^4.0.0"
+    semver "^6.0.0"
+
 ts-map@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ts-map/-/ts-map-1.0.3.tgz#1c4d218dec813d2103b7e04e4bcf348e1471c1ff"
@@ -11971,6 +12078,16 @@ type-is@~1.6.17, type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+type@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
+  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
+
+type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
+  integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
 
 typed-styles@^0.0.7:
   version "0.0.7"
@@ -12324,7 +12441,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.0.1, uuid@^3.3.2:
+uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -12494,6 +12611,16 @@ webpack-hot-middleware@^2.25.0:
     html-entities "^1.2.0"
     querystring "^0.2.0"
     strip-ansi "^3.0.0"
+
+webpack-log@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-1.2.0.tgz#a4b34cda6b22b518dbb0ab32e567962d5c72a43d"
+  integrity sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==
+  dependencies:
+    chalk "^2.1.0"
+    log-symbols "^2.1.0"
+    loglevelnext "^1.0.1"
+    uuid "^3.1.0"
 
 webpack-log@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2133,7 +2133,7 @@
     react-inspector "^4.0.0"
     uuid "^3.3.2"
 
-"@storybook/addon-docs@5.3.19":
+"@storybook/addon-docs@5.3.19", "@storybook/addon-docs@^5.3.19":
   version "5.3.19"
   resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-5.3.19.tgz#571dce4bd24664e5b2ea3570ccc9e238c901611a"
   integrity sha512-lGI4fDkfbg7gjj0ZTGBpGKykYKRd8mcLXY3M8/sdpA1a53dNABqL6kHoR/rbVJlk5tvEUY44QeEPKH+sOCu50g==
@@ -2265,7 +2265,7 @@
   dependencies:
     core-js "^3.0.1"
 
-"@storybook/client-api@5.3.19":
+"@storybook/client-api@5.3.19", "@storybook/client-api@^5.3.19":
   version "5.3.19"
   resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-5.3.19.tgz#7a5630bb8fffb92742b1773881e9004ee7fdf8e0"
   integrity sha512-Dh8ZLrLH91j9Fa28Gmp0KFUvvgK348aNMrDNAUdj4m4witz/BWQ2pxz6qq9/xFVErk/GanVC05kazGElqgYCRQ==


### PR DESCRIPTION
# Summary

close #61 

Added Doc Blocks for each embed types.

- [x] Figma
- [x] iframe
- [x] image
- [x] PDF
- ~[ ] link~ Just write `[Text](url)` 🤣 
- [x] Design - which takes a story id then render according to the story's `design` parameter

# Preview

https://storybook-addon-designs-git-feature-doc-blocks.pocka.vercel.app/?path=/docs/docs-advanced-usage--embed-multiple-designs#doc-blocks