### PR TITLE
Defer loading Figma preview

### DIFF
--- a/packages/storybook-addon-designs/src/register/components/Figma.tsx
+++ b/packages/storybook-addon-designs/src/register/components/Figma.tsx
@@ -30,15 +30,13 @@ export const Figma: SFC<Props> = ({ config }) => {
     }
 
     const embedHost = config.embedHost || location.hostname
-    const url = `https://www.figma.com/embed?embed_host=${embedHost}&url=${
-      config.url
-    }`
+    const url = `https://www.figma.com/embed?embed_host=${embedHost}&url=${config.url}`
 
     return {
       url,
-      allowFullscreen: config.allowFullscreen
+      allowFullscreen: config.allowFullscreen,
     }
   }, [config.url, config.allowFullscreen, config.embedHost])
 
-  return <IFrame config={iframeConfig} />
+  return <IFrame defer config={iframeConfig} />
 }


### PR DESCRIPTION
#77 

Defer loading Figma preview because of a "`document.fullscreenEnabled` is not updated" problem, which causes the linked issue above. I left other `<iframe>`s as-is but maybe other sites need to defer as well.