### PR TITLE
Use unique key for each tabs

### DIFF
--- a/packages/examples/stories/tests/issues/83.stories.js
+++ b/packages/examples/stories/tests/issues/83.stories.js
@@ -1,0 +1,49 @@
+import React from 'react'
+
+import { config, withDesign } from 'storybook-addon-designs'
+
+import { Button } from '../../Button'
+
+export default {
+  title: 'Tests/Issues/#83',
+  decorators: [withDesign],
+}
+
+const Template = () => <Button>Button</Button>
+
+export const story1 = Template.bind({})
+story1.story = {
+  parameters: {
+    design: config([
+      {
+        name: 'English',
+        type: 'iframe',
+        url: 'https://en.wikipedia.org/wiki/Main_Page',
+      },
+      {
+        name: 'Japanese',
+        type: 'iframe',
+        url:
+          'https://ja.wikipedia.org/wiki/%E3%83%A1%E3%82%A4%E3%83%B3%E3%83%9A%E3%83%BC%E3%82%B8',
+      },
+    ]),
+  },
+}
+
+export const story2 = Template.bind({})
+story2.story = {
+  parameters: {
+    design: config([
+      {
+        name: 'Deutsch',
+        type: 'iframe',
+        url: 'https://de.wikipedia.org/wiki/Wikipedia:Hauptseite',
+      },
+      {
+        name: 'Español',
+        type: 'iframe',
+        url: 'https://es.wikipedia.org/wiki/Wikipedia:Portada',
+      },
+    ]),
+  },
+}

--- a/packages/storybook-addon-designs/src/register/components/Tabs.tsx
+++ b/packages/storybook-addon-designs/src/register/components/Tabs.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { FC, ReactNode, useState } from 'react'
+import { FC, ReactNode, useEffect, useState } from 'react'
 import { jsx } from '@storybook/theming'
 
 import { Tabs as SbTabs } from '@storybook/components'
@@ -18,9 +18,13 @@ export interface TabsProps {
 export const Tabs: FC<TabsProps> = ({ tabs }) => {
   const [selected, setSelected] = useState(tabs[0].id)
 
+  useEffect(() => {
+    setSelected(tabs[0].id)
+  }, [tabs])
+
   return (
     <SbTabs absolute selected={selected} actions={{ onSelect: setSelected }}>
-      {tabs.map(tab => (
+      {tabs.map((tab) => (
         <div key={tab.id} id={tab.id} title={tab.name}>
           {tab.offscreen || selected === tab.id ? tab.content : null}
         </div>

--- a/packages/storybook-addon-designs/src/register/components/Wrapper.tsx
+++ b/packages/storybook-addon-designs/src/register/components/Wrapper.tsx
@@ -41,37 +41,37 @@ export const Wrapper: SFC<Props> = ({ config }) => {
   const tabs = [...(config instanceof Array ? config : [config])].map<Tab>(
     (cfg, i) => {
       const meta: Omit<Tab, 'content'> = {
-        id: `addon-designs-tab--${i}`,
+        id: JSON.stringify(cfg),
         name: cfg.name || cfg.type.toUpperCase(),
-        offscreen: cfg.offscreen ?? true
+        offscreen: cfg.offscreen ?? true,
       }
 
       switch (cfg.type) {
         case 'iframe':
           return {
             ...meta,
-            content: <IFrame config={cfg} />
+            content: <IFrame config={cfg} />,
           }
         case 'figma':
           return {
             ...meta,
             content: <Figma config={cfg} />,
-            offscreen: false
+            offscreen: false,
           }
         case 'pdf':
           return {
             ...meta,
-            content: <Pdf config={cfg} />
+            content: <Pdf config={cfg} />,
           }
         case 'image':
           return {
             ...meta,
-            content: <ImagePreview config={cfg} />
+            content: <ImagePreview config={cfg} />,
           }
         case 'link':
           return {
             ...meta,
-            content: <LinkPanel config={cfg} />
+            content: <LinkPanel config={cfg} />,
           }
       }
 
@@ -93,7 +93,7 @@ export const Wrapper: SFC<Props> = ({ config }) => {
               </Link>
             </Fragment>
           </Placeholder>
-        )
+        ),
       }
     }
   )


### PR DESCRIPTION
Fix #83.

Fixes key duplication between different stories.

[Preview Deploy: Tests / Issues / #83](https://storybook-addon-designs-4potv4b3h.vercel.app/?path=/story/tests-issues-83--story-2)