### PR TITLE
Simplify wrapper with storybook hooks API

### DIFF
--- a/packages/storybook-addon-designs/src/register/containers/Wrapper.tsx
+++ b/packages/storybook-addon-designs/src/register/containers/Wrapper.tsx
@@ -1,51 +1,25 @@
 /** @jsx jsx */
-import { Fragment, SFC, useEffect, useState } from 'react'
+import { FC } from 'react'
 import { jsx } from '@storybook/theming'
-import addons from '@storybook/addons'
-import { STORY_CHANGED } from '@storybook/core-events'
-
-import { Link, Placeholder, TabsState } from '@storybook/components'
+import { useParameter, useStorybookState } from '@storybook/api'
 
 import { Config } from '../../config'
-import { Events, ParameterName } from '../../addon'
+import { ParameterName } from '../../addon'
 
 import { Wrapper as Pure } from '../components/Wrapper'
 
 interface Props {
-  channel: ReturnType<typeof addons['getChannel']>
-
-  api: any
-
   active: boolean
 }
 
-export const Wrapper: SFC<Props> = ({ active, api, channel }) => {
-  const [config, setConfig] = useState<Config | Config[]>()
-  const [storyId, changeStory] = useState<string>()
-
-  useEffect(() => {
-    const onStoryChanged = (id: string) => {
-      changeStory(id)
-
-      const cfg = api.getParameters(id, ParameterName)
-
-      setConfig(prev => (cfg !== prev ? cfg : prev))
-    }
-
-    channel.on(Events.UpdateConfig, setConfig)
-    channel.on(STORY_CHANGED, onStoryChanged)
-
-    return () => {
-      channel.removeListener(Events.UpdateConfig, setConfig)
-      channel.removeListener(STORY_CHANGED, onStoryChanged)
-    }
-  }, [])
-
+export const Wrapper: FC<Props> = ({ active }) => {
   if (!active) {
     return null
   }
 
-  return <Pure key={storyId} config={config} />
+  const state = useStorybookState()
+  const config = useParameter(ParameterName) as Config
+  return <Pure key={state.storyId} config={config} />
 }
 
 export default Wrapper

--- a/packages/storybook-addon-designs/src/register/index.tsx
+++ b/packages/storybook-addon-designs/src/register/index.tsx
@@ -10,12 +10,7 @@ export default function register(renderTarget: 'panel' | 'tab') {
   addons.register(AddonName, api => {
     const title = 'Design'
     const render: Addon['render'] = ({ active, key }) => (
-      <Wrapper
-        key={key}
-        channel={addons.getChannel()}
-        api={api}
-        active={!!active}
-      />
+      <Wrapper key={key} active={!!active} />
     )
 
     if (renderTarget === 'tab') {


### PR DESCRIPTION
Issue: N/A

## What I did

I saw a problem where the design wasn't loading on the initial story until I switched stories and switched back. When I looked at the addon source I found that it's reimplementing a bunch of state management that's already handled by Storybook's hook API. So I updated the code accordingly.

## How to test

I ran the example in the monorepo to check the different examples, but I'm not sure I tested all cases. If you can test it or suggest the best way for me to test it, I'd be happy to follow up.