### PR TITLE
feat: present footer with component url in figspec

### DIFF
--- a/packages/storybook-addon-designs/package.json
+++ b/packages/storybook-addon-designs/package.json
@@ -18,10 +18,10 @@
     "preset.js"
   ],
   "dependencies": {
-    "@figspec/react": "^0.1.4"
+    "@figspec/react": "^0.1.6"
   },
   "devDependencies": {
-    "@figspec/components": "^0.1.2",
+    "@figspec/components": "^0.1.8",
     "@storybook/addon-docs": "6.2.8",
     "@storybook/addons": "6.2.8",
     "@storybook/client-api": "6.2.8",

--- a/packages/storybook-addon-designs/src/register/components/Figspec.tsx
+++ b/packages/storybook-addon-designs/src/register/components/Figspec.tsx
@@ -30,11 +30,11 @@ const fullscreen = css`
 type RenderItem =
   | {
       type: 'file'
-      props: Pick<FigspecFileViewerProps, 'documentNode' | 'renderedImages'>
+      props: Pick<FigspecFileViewerProps, 'documentNode' | 'renderedImages' | 'link'>
     }
   | {
       type: 'frame'
-      props: Pick<FigspecFrameViewerProps, 'nodes' | 'renderedImage'>
+      props: Pick<FigspecFrameViewerProps, 'nodes' | 'renderedImage' | 'link'>
     }
 
 type Remote<T, E = Error> =
@@ -136,6 +136,7 @@ export const Figspec: FC<Props> = ({ config }) => {
             props: {
               documentNode,
               renderedImages: images.images,
+              link: config.url
             },
           },
         })
@@ -165,6 +166,7 @@ export const Figspec: FC<Props> = ({ config }) => {
           props: {
             nodes,
             renderedImage: Object.values(images.images)[0],
+            link: config.url
           },
         },
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1227,7 +1227,7 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@figspec/components@^0.1.1", "@figspec/components@^0.1.2":
+"@figspec/components@^0.1.1":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@figspec/components/-/components-0.1.6.tgz#bf834309e931d88cc29fa4091ce7cba973bcb503"
   integrity sha512-IfK/VWC5P/Hyz48qkct8sD34Yhh0Cosgd637rR2412EMgXtkpqlbDPLqAQjPsgYgNCjsee4Wmx9JC3vPx0dD0Q==
@@ -1235,10 +1235,18 @@
     copy-to-clipboard "^3.0.0"
     lit-element "^2.4.0"
 
-"@figspec/react@^0.1.4":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@figspec/react/-/react-0.1.5.tgz#777e67e2bb8dd80ef14d6fd373320d12d27c8e7c"
-  integrity sha512-XIVBoj+E3vTWHcAo0Rii6uKtT+wbxRe16Ehj3RURo4BJ0D28eC30KaN7KrG3kQKzBLbuEHyk9215QrgtOo+UMw==
+"@figspec/components@^0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@figspec/components/-/components-0.1.8.tgz#a6cf28e66aaaaf8cfe75b53bccb4443692b12285"
+  integrity sha512-jSk3aREVOvQRncC/2HyieeOPxkjQmKyWn6prfXC+ijOHwIeR6jzhv5C/ryk4ZW2msXYAtPtIBL+/iF2pQVJ/Sg==
+  dependencies:
+    copy-to-clipboard "^3.0.0"
+    lit-element "^2.4.0"
+
+"@figspec/react@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@figspec/react/-/react-0.1.6.tgz#b5868d87f48270a901031aae847cfc76458ed5b6"
+  integrity sha512-oi0JL8uIXgJ+PWRl4LDxJ7WWa80E3jdYmi6wsHAFDq1vT0rKuyhqimEJzCezIrHHz4fXKpNRO98TO7ccma6hjw==
   dependencies:
     "@figspec/components" "^0.1.1"
 


### PR DESCRIPTION
Figspec will now present a footer with some metadata and link to the figma component, with a link to open in Figma:

![image](https://user-images.githubusercontent.com/1671563/118376014-bf717280-b5c5-11eb-9e91-cd4bc380b44c.png)
