### PR TITLE
Stabilize Figspec integration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
       description: Which design `type` is affected by the bug?
       options:
         - label: figma
-        - label: experimental-figspec
+        - label: figspec
         - label: link
         - label: image
         - label: iframe

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -19,7 +19,7 @@ A clear and concise description of any alternative solutions or features you've 
 **Design types**
 
 - [ ] `figma`
-- [ ] `experimental-figspec`
+- [ ] `figspec`
 - [ ] `link`
 - [ ] `image`
 - [ ] `iframe`

--- a/packages/examples/stories/docs/figspec/README.stories.mdx
+++ b/packages/examples/stories/docs/figspec/README.stories.mdx
@@ -5,32 +5,26 @@ import { Badge } from '@storybook/components'
 
 <Meta title="Docs/Figma (Figspec)/README" />
 
-# Embedding Figma designs via Figspec (Experimental)
+# Embedding Figma designs via Figspec
 
 <Subtitle>
   This document describes how to embed your Figma files/frames to your Storybook
   using <a href="https://github.com/pocka/figspec">Figspec</a>.
 </Subtitle>
 
-You can embed Figma files or frames with enchanced spec viewer (Figspec) with `experimental-figspec` type.
+You can embed Figma files or frames with enchanced spec viewer (Figspec) with `figspec` type.
 The addon will calls Figma API with provided Figma Token and renders your Figma files or frames using Figspec components with the result.
 
 **This feature requires you to include your Figma API Access Token to Storybook bundle.
 Make sure your Storybook is private and Understand the risk.**
 
-## Requirements
-
-You need to install both `@figspec/react` and `@figspec/components`.
-
-```sh
-$ yarn add -D @figspec/react @figspec/components
-```
+## Limitations
 
 Since `@figspec/components` being WebComponents, browser support is limited to those support CustomElements v1 and Shadow DOM.
 
 ## Usage
 
-Put a `design` parameter into your story with `type: "experimental-figspec"` and `url` pointing your Figma file/frame/prototype.
+Put a `design` parameter into your story with `type: "figspec"` and `url` pointing your Figma file/frame/prototype.
 
 You also provide your [Figma Personal Access Token](https://www.figma.com/developers/api#access-tokens) in `accessToken` field or `STORYBOOK_FIGMA_ACCESS_TOKEN` environment variable.
 
@@ -39,7 +33,7 @@ export const myStory = () => <MyComponent />
 
 myStory.parameters = {
   design: {
-    type: 'experimental-figspec',
+    type: 'figspec',
     url: '<YOUR_FIGMA_ITEM_URL>',
     accessToken: '<YOUR_FIGMA_ACCESS_TOKEN>',
   },
@@ -52,8 +46,8 @@ $ STORYBOOK_FIGMA_ACCESS_TOKEN=xxxx npm run storybook
 
 ## Parameter options
 
-| Option name                                             | Type                     | Default value | Description                                 |
-| ------------------------------------------------------- | ------------------------ | ------------- | ------------------------------------------- |
-| `type` <Badge status="positive">required</Badge>        | `"experimental-figspec"` |               | Fixed parameter. Will be changed v6.0-beta. |
-| `url` <Badge status="positive">required</Badge>         | `string` (URL)           |               | An URL to a Figma file/frame/prototype.     |
-| `accessToken` <Badge status="positive">required</Badge> | `string`                 |               |                                             | Your Figma Personal Access Token. |
+| Option name                                             | Type           | Default value | Description                             |
+| ------------------------------------------------------- | -------------- | ------------- | --------------------------------------- |
+| `type` <Badge status="positive">required</Badge>        | `"figspec"`    |               | Fixed parameter.                        |
+| `url` <Badge status="positive">required</Badge>         | `string` (URL) |               | An URL to a Figma file/frame/prototype. |
+| `accessToken` <Badge status="positive">required</Badge> | `string`       |               | Your Figma Personal Access Token.       |

--- a/packages/examples/stories/internal/blocks/figma-spec.stories.mdx
+++ b/packages/examples/stories/internal/blocks/figma-spec.stories.mdx
@@ -5,8 +5,6 @@ import { Figspec } from '../../../../storybook-addon-designs/src/blocks'
 
 # Figspec Block
 
-> **🚨 this block is experimental!**
-
 **This block requires you to include your Figma API Access Token to Storybook bundle.
 Make sure your Storybook is private and Understand the risk.**
 

--- a/packages/storybook-addon-designs/package.json
+++ b/packages/storybook-addon-designs/package.json
@@ -18,10 +18,10 @@
     "preset.js"
   ],
   "dependencies": {
-    "@figspec/react": "^0.1.6"
+    "@figspec/react": "^1.0.0"
   },
   "devDependencies": {
-    "@figspec/components": "^0.1.8",
+    "@figspec/components": "^1.0.0",
     "@storybook/addon-docs": "6.3.2",
     "@storybook/addons": "6.3.2",
     "@storybook/api": "6.3.2",

--- a/packages/storybook-addon-designs/src/blocks.tsx
+++ b/packages/storybook-addon-designs/src/blocks.tsx
@@ -149,48 +149,39 @@ export const DocBlockBase: FC<BlocksCommonProps> = ({
   )
 }
 
-export const Figma: FC<
-  Omit<config.FigmaConfig, 'type'> & BlocksCommonProps
-> = ({ placeholder, ...props }) => (
-  <DocBlockBase placeholder={placeholder ?? 'Design (Figma)'} {...props}>
-    <FigmaInternal config={{ type: 'figma', ...props }} />
-  </DocBlockBase>
-)
+export const Figma: FC<Omit<config.FigmaConfig, 'type'> & BlocksCommonProps> =
+  ({ placeholder, ...props }) => (
+    <DocBlockBase placeholder={placeholder ?? 'Design (Figma)'} {...props}>
+      <FigmaInternal config={{ type: 'figma', ...props }} />
+    </DocBlockBase>
+  )
 
-/**
- * @experimental
- */
 export const Figspec: FC<
   Omit<config.FigspecConfig, 'type'> & BlocksCommonProps
 > = ({ placeholder, ...props }) => {
-  console.warn(
-    "🚨 `Figspec` block is currently experimental and requires you to include your figma's access token in your storybook build, use with caution!"
-  )
   return (
     <DocBlockBase placeholder={placeholder ?? 'Design (Figma-Spec)'} {...props}>
-      <FigspecInternal config={{ type: 'experimental-figspec', ...props }} />
+      <FigspecInternal config={{ type: 'figspec', ...props }} />
     </DocBlockBase>
   )
 }
 
-export const IFrame: FC<
-  Omit<config.IFrameConfig, 'type'> & BlocksCommonProps
-> = ({ placeholder, ...props }) => (
-  <DocBlockBase placeholder={placeholder ?? 'Design (iframe)'} {...props}>
-    <IFrameInternal config={props} />
-  </DocBlockBase>
-)
+export const IFrame: FC<Omit<config.IFrameConfig, 'type'> & BlocksCommonProps> =
+  ({ placeholder, ...props }) => (
+    <DocBlockBase placeholder={placeholder ?? 'Design (iframe)'} {...props}>
+      <IFrameInternal config={props} />
+    </DocBlockBase>
+  )
 
 // Image would do shadowing the native variable (Image constructor, which creates
 // HTMLImageElement), but I think it doesn't matter since there is less chance to
 // use Image constructor in MDX.
-export const Image: FC<
-  Omit<config.ImageConfig, 'type'> & BlocksCommonProps
-> = ({ placeholder, ...props }) => (
-  <DocBlockBase placeholder={placeholder ?? 'Design (Image)'} {...props}>
-    <ImagePreview config={{ type: 'image', ...props }} />
-  </DocBlockBase>
-)
+export const Image: FC<Omit<config.ImageConfig, 'type'> & BlocksCommonProps> =
+  ({ placeholder, ...props }) => (
+    <DocBlockBase placeholder={placeholder ?? 'Design (Image)'} {...props}>
+      <ImagePreview config={{ type: 'image', ...props }} />
+    </DocBlockBase>
+  )
 
 const AbsoluteLocater = styled.div`
   position: absolute;

--- a/packages/storybook-addon-designs/src/config.ts
+++ b/packages/storybook-addon-designs/src/config.ts
@@ -57,7 +57,7 @@ export interface FigmaConfig extends IFrameConfigBase {
  * Render Figma files or frames via [figspec](https://github.com/pocka/figspec).
  */
 export interface FigspecConfig extends ConfigBase {
-  type: 'experimental-figspec'
+  type: 'figspec' | 'experimental-figspec'
 
   /**
    * An URL for the Figma file or frame.

--- a/packages/storybook-addon-designs/src/register/components/Wrapper.tsx
+++ b/packages/storybook-addon-designs/src/register/components/Wrapper.tsx
@@ -59,7 +59,14 @@ export const Wrapper: SFC<Props> = ({ config }) => {
             content: <Figma config={cfg} />,
             offscreen: false,
           }
+        case 'figspec':
         case 'experimental-figspec':
+          if (cfg.type === 'experimental-figspec') {
+            console.warn(
+              '[storybook-addon-designs] `experimental-figspec` is deprecated. We will remove it in v7.0. Please replace it to `figspec` type.'
+            )
+          }
+
           return {
             ...meta,
             content: (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,21 +1195,21 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@figspec/components@^0.1.1", "@figspec/components@^0.1.8":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@figspec/components/-/components-0.1.10.tgz#cd80a9ef66dbf35c4a36ae182dc8fc5405aa7c33"
-  integrity sha512-1Iy87RbTwwoxpXYLNkYRWpIYc/Ao02+56WVzp7TC9k52h3dv9+TJDvzqFpTmA9v1uaCQqnH4hq4LrJjciYpUoA==
+"@figspec/components@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@figspec/components/-/components-1.0.0.tgz#b1ddf0593173157cb5e79e50073ca1491bb7c6dc"
+  integrity sha512-a8sgP0YLJ3H0g0pdZPYecxfp9JNVQUTaaU3xcSci8duHXTGkJ7X8QPPCBbyhB+MoxMxnsAh8GjkfZHEr9oIoPQ==
   dependencies:
     copy-to-clipboard "^3.0.0"
     lit-element "^2.4.0"
     lit-html "^1.1.1"
 
-"@figspec/react@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@figspec/react/-/react-0.1.6.tgz#b5868d87f48270a901031aae847cfc76458ed5b6"
-  integrity sha512-oi0JL8uIXgJ+PWRl4LDxJ7WWa80E3jdYmi6wsHAFDq1vT0rKuyhqimEJzCezIrHHz4fXKpNRO98TO7ccma6hjw==
+"@figspec/react@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@figspec/react/-/react-1.0.0.tgz#226ff85e146038b284ddf1ddbc086d2d14fe370a"
+  integrity sha512-BkOu3RsKF5vCtPoqsc6Oeyxw4wr9GesFrB9/wDHFqgjzhWsw8erFxCsPxsjdlJD8d8OWVHoM6SWxAaGe/pLdxg==
   dependencies:
-    "@figspec/components" "^0.1.1"
+    "@figspec/components" "^1.0.0"
 
 "@gar/promisify@^1.0.1":
   version "1.1.2"


### PR DESCRIPTION
Added `type: "figspec"` and Deprecated `type: "experimental-figspec"`. The latter will be removed on v7.0.