### PR TITLE
fix: Add missing peer dependencies

### DIFF
--- a/packages/storybook-addon-designs/package.json
+++ b/packages/storybook-addon-designs/package.json
@@ -36,11 +36,11 @@
     "typescript": "^3.7.0"
   },
   "peerDependencies": {
-    "@storybook/addon-docs": "6.3.2",
-    "@storybook/addons": "6.3.2",
-    "@storybook/api": "6.3.2",
-    "@storybook/components": "6.3.2",
-    "@storybook/theming": "6.3.2"
+    "@storybook/addon-docs": "^6.0.0",
+    "@storybook/addons": "^6.0.0",
+    "@storybook/api": "^6.0.0",
+    "@storybook/components": "^6.0.0",
+    "@storybook/theming": "^6.0.0"
   },
   "scripts": {
     "dev": "tsc --watch --preserveWatchOutput",

--- a/packages/storybook-addon-designs/package.json
+++ b/packages/storybook-addon-designs/package.json
@@ -35,6 +35,13 @@
     "react": "^16.8.4",
     "typescript": "^3.7.0"
   },
+  "peerDependencies": {
+    "@storybook/addon-docs": "6.3.2",
+    "@storybook/addons": "6.3.2",
+    "@storybook/api": "6.3.2",
+    "@storybook/components": "6.3.2",
+    "@storybook/theming": "6.3.2"
+  },
   "scripts": {
     "dev": "tsc --watch --preserveWatchOutput",
     "build": "yarn build:esm && yarn build:cjs",


### PR DESCRIPTION
We require these at runtime, so they need to at least be
peerDependencies (if not normal dependencies).

Packagers such as Yarn PnP and pnpm use an unambiguous dependency
layout, where packages are only able to require their declared
dependencies. In order to consume dependencies fulfilled by our
ancestors in these scenarios, we have to declare them as
peerDependencies. This will cause the package manager to "forward"
matching dependencies declared by our parent.