### PR TITLE
Use static tab name for renderTarget=tab

### DIFF
--- a/packages/storybook-addon-designs/src/register/index.tsx
+++ b/packages/storybook-addon-designs/src/register/index.tsx
@@ -36,7 +36,7 @@ export default function register(renderTarget: 'panel' | 'tab') {
 
     if (renderTarget === 'tab') {
       addons.add(PanelName, {
-        title,
+        title: DEFAULT_TAB_NAME,
         render,
         type: types.TAB,
         paramKey: ParameterName,


### PR DESCRIPTION
fix #134 

Storybook does not support function title for the `<Tab>` component. Changed to always use the default tab name (`Design`) when `renderTarget` is set to `"tab"`.

- [Preview deploy (tab mode)](https://storybook-addon-designs-qn5yuylnq-pocka.vercel.app/tab/?path=/story/docs-figma-examples--embed-file)