### PR TITLE
fix: update storybook addons import for Storybook 7.0

### DIFF
--- a/packages/storybook-addon-designs/src/index.ts
+++ b/packages/storybook-addon-designs/src/index.ts
@@ -1,4 +1,4 @@
-import addons, { makeDecorator, StoryWrapper } from "@storybook/addons";
+import { addons, makeDecorator, StoryWrapper } from "@storybook/addons";
 
 import { Events, PanelName, ParameterName } from "./addon";
 import { Config } from "./config";


### PR DESCRIPTION
In Storybook 7.0, the export from `@storybook/addons` changed to only contain names exports.
The change in this PR is backwards compatible with 6.5, but necessary in Storybook 7.0, else the addon will not be registered.