### PR TITLE
Fix support for Storybook 7.0.0-alpha

### DIFF
--- a/packages/storybook-addon-designs/src/register/index.tsx
+++ b/packages/storybook-addon-designs/src/register/index.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import addons, { types } from "@storybook/addons";
+import { addons, types } from "@storybook/addons";
 import { useParameter } from "@storybook/api";
 import { AddonPanel } from "@storybook/components";
 import { jsx } from "@storybook/theming";


### PR DESCRIPTION
This PR updates the `addons` import within register, which was left out in the [previous Storybook 7 update](https://github.com/pocka/storybook-addon-designs/pull/160).

See: https://github.com/pocka/storybook-addon-designs/issues/172